### PR TITLE
Update ZoLa link to production

### DIFF
--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -41,7 +41,7 @@
         <li {{! template-lint-disable "nested-interactive" }}
           onmousemove={{action 'handleHoverListItem' lot}} role="button">
           <hr class="small-margin">
-          <a class="button--tax-lot button expanded gray text-orange no-margin" href="https://zola.planninglabs.nyc/lot/{{lot.boro}}/{{lot.block}}/{{lot.lot}}" target="_blank" rel="noopener">
+          <a class="button--tax-lot button expanded gray text-orange no-margin" href="https://zola.planning.nyc.gov/lot/{{lot.boro}}/{{lot.block}}/{{lot.lot}}" target="_blank" rel="noopener">
             <span class="bbl">{{lot.boroName}}, Block {{lot.block}}, Lot {{lot.lot}}</span>
             <strong class="address">{{lot.address}}</strong>
             <span class="prompt">{{fa-icon 'external-link'}} View this lot in ZoLa</span>


### PR DESCRIPTION
This updates the deprecated zola.planninglabs.nyc link to the SSL-enabled production link.