### PR TITLE
Updating netlify config to set node version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
 command = "yarn build --environment=staging"
+environment = { NODE_VERSION = "12.18.4" }
 
 [context.master]
 command = "yarn build --environment=production"
+environment = { NODE_VERSION = "12.18.4" }
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [build]
 command = "yarn build --environment=staging"
-environment = { NODE_VERSION = "12.18.4" }
+environment = { NODE_VERSION = "10.18.0" }
 
 [context.master]
 command = "yarn build --environment=production"
-environment = { NODE_VERSION = "12.18.4" }
+environment = { NODE_VERSION = "10.18.0" }
 


### PR DESCRIPTION
This PR fixes netlify build errors happening after changing to new ubuntu version.

Changes Proposed:
- Updates netlify config to explicitly set node version

Addresses [AB#4918](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4918)
