### PR TITLE
9400 ensure use of geosearch-v2

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -34,6 +34,7 @@ module.exports = function(environment) {
     'labs-search': {
       host: (environment === 'devlocal') ? '//localhost:4000' : 'https://search-api-production.herokuapp.com',
       route: 'search',
+      helpers: ['geosearch-v2', 'city-map-street-search', 'city-map-alteration'],
     },
 
     fontawesome: {


### PR DESCRIPTION
Blocked by/Depends on Depends on https://github.com/NYCPlanning/labs-search-api/pull/58

Fixes [AB#9401](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9400)