### PR TITLE
10145 - Display local law names and dates correctly

### DIFF
--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -88,7 +88,7 @@ export default class MapPopupContent extends Component {
       .filter(d => d.properties.type === 'streetnamechange');
 
     streetNameChanges.forEach((d) => {
-      d.properties.ll_effecti = moment(d.properties.ll_effecti, 'MM/DD/YYYY').format('MMM D, YYYY'); // eslint-disable-line
+      d.properties.lleffectdt = moment(d.properties.lleffectdt, 'MM/DD/YYYY').format('MMM D, YYYY'); // eslint-disable-line
       return d;
     });
 

--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -26,9 +26,9 @@
     <ul class="popup-list no-bullet no-margin">
       {{#each streetNameChanges as |nameChange|}}
         <li>
-          <a class="popup-button clearfix"  href="https://laws.council.nyc.gov/legislation/int-{{nameChange.properties.intronumbe}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener">
-            <strong class="link-name float-left">{{fa-icon 'external-link'}} {{nameChange.properties.honoraryna}}</strong>
-            <span class="date float-right">{{nameChange.properties.ll_effecti}}</span>
+          <a class="popup-button clearfix"  href="https://council.nyc.gov/legislation/int-{{nameChange.properties.intro_num}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener">
+            <strong class="link-name float-left">{{fa-icon 'external-link'}} {{nameChange.properties.honor_name}}</strong>
+            <span class="date float-right">{{nameChange.properties.lleffectdt}}</span>
           </a>
         </li>
       {{/each}}


### PR DESCRIPTION
This PR attempts to address AB[#10145](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=10145). The front-end was referencing properties which have since been renamed and they've been changed to match those on Carto.

One outstanding issue is that each of these local laws is currently trying to link to the legislative text on council.nyc.gov. They have since changed their website and now the previous method we used of passing params to the link no longer works. These params have been replaced with an individual ID for each piece of legislation. There is a council API available to the public, but displaying this information on the Streets front end instead of linking to the council's hosted content would require an additional feature in the application.