### PR TITLE
Remove links to local laws

### DIFF
--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -25,11 +25,9 @@
     <h4 class="popup-header">Local Law Names</h4>
     <ul class="popup-list no-bullet no-margin">
       {{#each streetNameChanges as |nameChange|}}
-        <li>
-          <a class="popup-button clearfix"  href="https://council.nyc.gov/legislation/int-{{nameChange.properties.intro_num}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener">
-            <strong class="link-name float-left">{{fa-icon 'external-link'}} {{nameChange.properties.honor_name}}</strong>
-            <span class="date float-right">{{nameChange.properties.lleffectdt}}</span>
-          </a>
+        <li class="popup-button clearfix">
+          <strong class="link-name float-left">{{fa-icon 'external-link'}} {{nameChange.properties.honor_name}}</strong>
+          <span class="date float-right">{{nameChange.properties.lleffectdt}}</span>
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
This PR removes the links to local laws on the NYC Council site temporarily, pending the completion of AB[#10457](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/2022/Q3/Sprint%20R?workitem=10457).