### PR TITLE
Bug/3745 – Fix incorrect lat / lng assignments

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -130,7 +130,7 @@ export default class ApplicationController extends ParachuteController {
     const pitch = e.target.getPitch();
     const bearing = e.target.getBearing();
     let zoom = e.target.getZoom();
-    let { lat: lng, lng: lat } = e.target.getCenter();
+    let { lat, lng } = e.target.getCenter();
 
     lng = precisionRound(lng, 4);
     lat = precisionRound(lat, 4);


### PR DESCRIPTION
"lat" and "lng" variables were being assigned to each other in the application, causing the query params in the link to be incorrect. Assignment has been corrected.