### PR TITLE
3745 – Fix incorrect lat / lng query params

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -91,7 +91,7 @@ export default class ApplicationController extends ParachuteController {
 
   @computed('lat', 'lng')
   get center() {
-    return [this.get('lat'), this.get('lng')];
+    return [this.get('lng'), this.get('lat')];
   }
 
   shareURL = window.location.href;


### PR DESCRIPTION
An update to #328, this PR inverts lat and lng values in getCenter function to properly display the map when navigating to Streets from an external link or refresh.