### PR TITLE
Bug/11270 – Conditionally display pop-up content based on enabled layers

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -206,17 +206,11 @@ export default class ApplicationController extends ParachuteController {
   @action
   @trackEvent('click', 'popup', 'popupLocation')
   handleMapClick(e) {
-    const citymapLayerDisabled = this.get('model').layerGroups.toArray().filter((layerGroup) => { // eslint-disable-line
-      return layerGroup.get('visible');
-    }).find(layer => layer.id === 'citymap') === undefined;
+    const citymapLayerDisabled = this.get('model').layerGroups.toArray().filter(layerGroup => layerGroup.get('visible')).find(layer => layer.id === 'citymap') === undefined;
 
-    const pendingAmendmentsLayerDisabled = this.get('model').layerGroups.toArray().filter((layerGroup) => { // eslint-disable-line
-      return layerGroup.get('visible');
-    }).find(layer => layer.id === 'amendments-pending') === undefined;
+    const pendingAmendmentsLayerDisabled = this.get('model').layerGroups.toArray().filter(layerGroup => layerGroup.get('visible')).find(layer => layer.id === 'amendments-pending') === undefined;
 
-    const amendmentsLayerDisabled = this.get('model').layerGroups.toArray().filter((layerGroup) => { // eslint-disable-line
-      return layerGroup.get('visible');
-    }).find(layer => layer.id === 'amendments') === undefined;
+    const amendmentsLayerDisabled = this.get('model').layerGroups.toArray().filter(layerGroup => layerGroup.get('visible')).find(layer => layer.id === 'amendments') === undefined;
 
     // Open the popup and clear its content (defaults to showing spinner)
     this.set('popupFeatures', null);

--- a/config/environment.js
+++ b/config/environment.js
@@ -65,7 +65,7 @@ module.exports = function(environment) {
     ENV.namespace = 'v1';
 
     // Enable this line to specify the address for a locally run Layers API
-    // ENV.host = 'http://localhost:3000';
+    ENV.host = 'http://localhost:3000';
 
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;


### PR DESCRIPTION
This PR addresses AB[#11270](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/11270). The pop-up content was previously displaying all the feature information (ie. amendments, pending amendments, and tax-lots) even if the corresponding layer was disabled. It now conditionally renders this info based on which layers are enabled.