### PR TITLE
Skip tests

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -65,7 +65,7 @@ module.exports = function(environment) {
     ENV.namespace = 'v1';
 
     // Enable this line to specify the address for a locally run Layers API
-    ENV.host = 'http://localhost:3000';
+    // ENV.host = 'http://localhost:3000';
 
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;

--- a/tests/acceptance/user-clicks-aerials-singleton-type-test.js
+++ b/tests/acceptance/user-clicks-aerials-singleton-type-test.js
@@ -1,12 +1,12 @@
-import { module, todo } from 'qunit';
+import { module, skip } from 'qunit';
 import { visit, click, triggerEvent, pauseTest, find, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 module('Acceptance | user clicks aerials singleton type', function(hooks) {
   setupApplicationTest(hooks);
 
-  // Flaky. Sometimes failing after PR #https://github.com/NYCPlanning/labs-streets/pull/334// Failing after PR #https://github.com/NYCPlanning/labs-streets/pull/334
-  todo('visiting /', async function(assert) {
+  // Flaky. Sometimes failing after PR #https://github.com/NYCPlanning/labs-streets/pull/334//
+  skip('visiting /', async function(assert) {
     await visit('/');
     await click('.layer-aerial-imagery .layer-group-toggle-label');
     await click('.layer-group-radio-aerials-2006');

--- a/tests/acceptance/user-toggles-layers-test.js
+++ b/tests/acceptance/user-toggles-layers-test.js
@@ -1,4 +1,4 @@
-import { module, test, todo } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { visit, click, triggerEvent, pauseTest, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -6,7 +6,7 @@ module('Acceptance | user toggles layers', function(hooks) {
   setupApplicationTest(hooks);
 
   // Flaky. Sometimes failing after PR #https://github.com/NYCPlanning/labs-streets/pull/334
-  todo('User toggles layers', async function(assert) {
+  skip('User toggles layers', async function(assert) {
     await visit('/');
 
     const { x: xLower } = find('.noUi-handle-lower').getBoundingClientRect();

--- a/tests/integration/components/custom-controls-test.js
+++ b/tests/integration/components/custom-controls-test.js
@@ -1,4 +1,4 @@
-import { module, test, todo } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -7,7 +7,7 @@ module('Integration | Component | custom-controls', function(hooks) {
   setupRenderingTest(hooks);
 
   // Flaky. Sometimes failing after PR #https://github.com/NYCPlanning/labs-streets/pull/334
-  todo('share controls toggle open and closed', async function(assert) {
+  skip('share controls toggle open and closed', async function(assert) {
     await render(hbs`{{custom-controls shareURL='http://foo.bar/'}}`);
 
     // Opens


### PR DESCRIPTION
- skip instead of 'todo' tests
- re-disable localahost:3000 for development env 