### PR TITLE
Task/13342 add city section layer

### DIFF
--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -95,6 +95,28 @@ export default class MapPopupContent extends Component {
     return streetNameChanges;
   }
 
+  @computed('features')
+  get sectionMapLink() {
+    const features = this.get('features');
+    if (features === null) return features;
+
+    const sectionMapLink = features
+      .filter(d => d.properties.type === 'streetsect')
+      .map((feature) => {
+        const { properties } = feature;
+        const { do_path, last_date } = properties;
+
+        return {
+          feature,
+          do_path,
+          last_date: moment(last_date).format('MMM D, YYYY'),
+          section_info: do_path.split('.com/')[1],
+        };
+      });
+
+    return sectionMapLink;
+  }
+
   @argument
   features = [];
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -218,6 +218,8 @@ export default class ApplicationController extends ParachuteController {
 
     const amendmentsLayerDisabled = this.get('model').layerGroups.toArray().filter(layerGroup => layerGroup.get('visible')).find(layer => layer.id === 'amendments') === undefined;
 
+    const streetSectionLayerDisabled = this.get('model').layerGroups.toArray().filter(layerGroup => layerGroup.get('visible')).find(layer => layer.id === 'street-sections') === undefined;
+
     // Open the popup and clear its content (defaults to showing spinner)
     this.set('popupFeatures', null);
     this.set('popupLocation', e.lngLat);
@@ -225,7 +227,7 @@ export default class ApplicationController extends ParachuteController {
     // Query and set the popup content
     const { lng, lat } = e.lngLat;
     const SQL = `
-    SELECT the_geom, 'alteration' AS type, altmappdf, status, effect_dt AS effective, NULL AS bbl, NULL AS address
+    SELECT the_geom, 'alteration' AS type, altmappdf, status, effect_dt as effective, NULL as bbl, NULL as address, NULL::timestamp as last_date, NULL as do_path
       FROM dcp_dcm_city_map_alterations
       WHERE (effect_dt IS NOT NULL
               OR status = '13')
@@ -239,8 +241,20 @@ export default class ApplicationController extends ParachuteController {
           )
         )
     UNION ALL
-    SELECT the_geom, 'taxlot' AS type, NULL as altmappdf, NULL as status, NULL as effective, bbl, address
+    SELECT the_geom, 'taxlot' AS type, NULL as altmappdf, NULL as status, NULL as effective, bbl, address, NULL::timestamp as last_date, NULL as do_path
       FROM dcp_mappluto
+        WHERE ST_Intersects(
+          the_geom,
+          ST_SetSRID(
+            ST_MakePoint(
+              ${lng},
+              ${lat}
+            ),4326
+          )
+        )
+    UNION ALL
+    SELECT the_geom, 'streetsect' AS type, NULL as altmappdf, NULL as status, NULL as effective, NULL as bbl, NULL as address, last_date, do_path 
+      FROM dcp_final_section_map_index
         WHERE ST_Intersects(
           the_geom,
           ST_SetSRID(
@@ -271,8 +285,9 @@ export default class ApplicationController extends ParachuteController {
         let filteredFeatures = FC.features;
 
         if (citymapLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => feature.properties.type !== 'taxlot');
-        if (amendmentsLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => (feature.properties.type === 'alteration' && feature.properties.effective === null) || feature.properties.type === 'taxlot');
-        if (pendingAmendmentsLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => (feature.properties.type === 'alteration' && feature.properties.effective !== null) || feature.properties.type === 'taxlot');
+        if (amendmentsLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => (feature.properties.type === 'alteration' && feature.properties.effective === null) || feature.properties.type === 'taxlot' || feature.properties.type === 'streetsect');
+        if (pendingAmendmentsLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => (feature.properties.type === 'alteration' && feature.properties.effective !== null) || feature.properties.type === 'taxlot' || feature.properties.type === 'streetsect');
+        if (streetSectionLayerDisabled) filteredFeatures = filteredFeatures.filter(feature => (feature.properties.type !== 'streetsect'));
 
         this.set('popupFeatures', [...filteredFeatures, ...streetNameChanges]);
       });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -23,6 +23,7 @@ export default class ApplicationRoute extends Route {
           { id: 'citymap', visible: true },
           { id: 'street-centerlines', visible: true },
           { id: 'pierhead-bulkhead-lines', visible: true },
+          { id: 'street-sections', visible: false },
           { id: 'amendments', visible: true },
           { id: 'amendments-pending', visible: false },
           { id: 'arterials', visible: false },

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -261,6 +261,16 @@
         {{/labs-ui/layer-group-toggle}}
       {{/lookup-layer-group}}
 
+      {{#lookup-layer-group for='street-sections' as |layerGroup|}}
+        {{#labs-ui/layer-group-toggle
+          label=layerGroup.model.legend.label
+          tooltip=layerGroup.model.legend.tooltip
+          active=layerGroup.model.visible
+          icon=layerGroup.model.legend.icon
+        }}
+        {{/labs-ui/layer-group-toggle}}
+      {{/lookup-layer-group}}
+
       {{#lookup-layer-group for='amendments' as |layerGroup|}}
         {{#labs-ui/layer-group-toggle
           label=layerGroup.model.legend.label

--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -33,6 +33,22 @@
     </ul>
   {{/if}}
 
+  {{#if sectionMapLink}}
+    <hr class="small-margin">
+    <h4 class="popup-header">Street Section Map</h4>
+    <ul class="popup-list no-bullet">
+      {{#each sectionMapLink as |sectionMap|}}
+        <li class="dark-gray" {{! template-lint-disable "nested-interactive" }}
+          onmousemove={{action 'handleHoverListItem' sectionMap}} role="button">
+          <a class="popup-button clearfix" href="{{sectionMap.do_path}}" target="_blank" rel="noopener">
+            <strong class="link-name float-left">{{fa-icon 'external-link-alt'}} <span class="filename">{{sectionMap.section_info}}</span></strong>
+            <span class="date float-right">Effective {{sectionMap.last_date}}</span>
+          </a>
+        </li>
+      {{/each}}
+    </ul>
+  {{/if}}
+
   {{#if cleanLots}}
     <ul class="popup-list no-bullet no-margin">
       {{#each cleanLots as |lot|}}


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->
This PR adds a new layer, street-sections. Also updates popup tooltip when clicking on geography to include a link to the Street Section map and its effective date.

Partially resolves [AB#13342](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/13342).

Should be merged in AFTER the [appropriate changes to labs-layers-api](https://github.com/NYCPlanning/labs-layers-api/pull/314) are approved.