### PR TITLE
Update netlify.toml to use staging layers api in develop context

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 command = "yarn build"
 environment = { NODE_VERSION = "12.18.4" }
 
+[context.develop]
+command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=staging"
+environment = {NODE_VERSION = "12.18.4"}
+
 [context.data-qa]
 command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=staging"
 environment = {NODE_VERSION = "12.18.4"}


### PR DESCRIPTION
This PR just adds a section to `netlify.toml` to correctly map deployments of the develop branch to use the "staging" layers-api environment.
