### PR TITLE
Update environment.js to disable broken Search API helpers

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -39,7 +39,7 @@ module.exports = function(environment) {
     'labs-search': {
       host: (environment === 'devlocal') ? '//localhost:4000' : 'https://search-api-production.herokuapp.com',
       route: 'search',
-      helpers: ['geosearch-v2', 'city-map-street-search', 'city-map-alteration'],
+      helpers: ['geosearch-v2'],
     },
 
     fontawesome: {


### PR DESCRIPTION
This PR disables two Search API helpers that are currently broken. We will soon be introducing changes to Search API that will cause these helpers to return errors instead of silently failing, so we are disabling them for now.