### PR TITLE
Update copy for geographies without a Street Section Map

### DIFF
--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -99,21 +99,23 @@ export default class MapPopupContent extends Component {
   get sectionMapLink() {
     const features = this.get('features');
     if (features === null) return features;
-
+    
     const sectionMapLink = features
-      .filter(d => d.properties.type === 'streetsect')
-      .map((feature) => {
-        const { properties } = feature;
-        const { do_path, last_date } = properties;
+    .filter(d => d.properties.type === 'streetsect')
+    .map((feature) => {
+      const { properties } = feature;
+        const { do_path, last_date, boro } = properties;
 
         return {
           feature,
           do_path,
+          boro,
+          boroname: boroLookup[boro],
           last_date: moment(last_date).format('MMM D, YYYY'),
           section_info: do_path.split('.com/')[1],
         };
       });
-
+      
     return sectionMapLink;
   }
 

--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -99,11 +99,11 @@ export default class MapPopupContent extends Component {
   get sectionMapLink() {
     const features = this.get('features');
     if (features === null) return features;
-    
+
     const sectionMapLink = features
-    .filter(d => d.properties.type === 'streetsect')
-    .map((feature) => {
-      const { properties } = feature;
+      .filter(d => d.properties.type === 'streetsect')
+      .map((feature) => {
+        const { properties } = feature;
         const { do_path, last_date, boro } = properties;
 
         return {
@@ -115,7 +115,7 @@ export default class MapPopupContent extends Component {
           section_info: do_path.split('.com/')[1],
         };
       });
-      
+
     return sectionMapLink;
   }
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -227,7 +227,7 @@ export default class ApplicationController extends ParachuteController {
     // Query and set the popup content
     const { lng, lat } = e.lngLat;
     const SQL = `
-    SELECT the_geom, 'alteration' AS type, altmappdf, status, effect_dt as effective, NULL as bbl, NULL as address, NULL::timestamp as last_date, NULL as do_path
+    SELECT the_geom, 'alteration' AS type, altmappdf, status, effect_dt AS effective, NULL AS bbl, NULL AS address, NULL::timestamp AS last_date, NULL AS do_path, NULL AS boro
       FROM dcp_dcm_city_map_alterations
       WHERE (effect_dt IS NOT NULL
               OR status = '13')
@@ -241,7 +241,7 @@ export default class ApplicationController extends ParachuteController {
           )
         )
     UNION ALL
-    SELECT the_geom, 'taxlot' AS type, NULL as altmappdf, NULL as status, NULL as effective, bbl, address, NULL::timestamp as last_date, NULL as do_path
+    SELECT the_geom, 'taxlot' AS type, NULL AS altmappdf, NULL AS status, NULL AS effective, bbl, address, NULL::timestamp AS last_date, NULL AS do_path, NULL AS boro
       FROM dcp_mappluto
         WHERE ST_Intersects(
           the_geom,
@@ -253,7 +253,7 @@ export default class ApplicationController extends ParachuteController {
           )
         )
     UNION ALL
-    SELECT the_geom, 'streetsect' AS type, NULL as altmappdf, NULL as status, NULL as effective, NULL as bbl, NULL as address, last_date, do_path 
+    SELECT the_geom, 'streetsect' AS type, NULL AS altmappdf, NULL AS status, NULL AS effective, NULL AS bbl, NULL AS address, last_date, do_path, boro 
       FROM dcp_final_section_map_index
         WHERE ST_Intersects(
           the_geom,

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -283,6 +283,13 @@ hr.small-margin {
   }
 }
 
+.null-section-map{
+  display: flex;
+  flex-wrap: wrap;
+  max-height: min-content;
+  max-width: 15rem;
+}
+
 // Multi-column lists
 .list-float-3 {
   @include clearfix;

--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -38,13 +38,19 @@
     <h4 class="popup-header">Street Section Map</h4>
     <ul class="popup-list no-bullet">
       {{#each sectionMapLink as |sectionMap|}}
-        <li class="dark-gray" {{! template-lint-disable "nested-interactive" }}
-          onmousemove={{action 'handleHoverListItem' sectionMap}} role="button">
-          <a class="popup-button clearfix" href="{{sectionMap.do_path}}" target="_blank" rel="noopener">
-            <strong class="link-name float-left">{{fa-icon 'external-link-alt'}} <span class="filename">{{sectionMap.section_info}}</span></strong>
-            <span class="date float-right">Effective {{sectionMap.last_date}}</span>
-          </a>
-        </li>
+        {{#if sectionMap.do_path}}
+          <li class="dark-gray" {{! template-lint-disable "nested-interactive" }}
+            onmousemove={{action 'handleHoverListItem' sectionMap}} role="button">
+            <a class="popup-button clearfix" href="{{sectionMap.do_path}}" target="_blank" rel="noopener">
+              <strong class="link-name float-left">{{fa-icon 'external-link-alt'}} <span class="filename">{{sectionMap.section_info}}</span></strong>
+              <span class="date float-right">Effective {{sectionMap.last_date}}</span>
+            </a>
+          </li>
+        {{else}}
+          <span class="null-section-map">
+            There is no available digitized street section map for this location. For more information please contact the {{sectionMap.boroname}} Borough President's Topographical Bureau.
+          </span>
+        {{/if}}
       {{/each}}
     </ul>
   {{/if}}


### PR DESCRIPTION
This PR updates the tooltip for geographies which do not have Street Section Maps.

Supports [AB#13342](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/13342)
![Screen Shot 2023-06-16 at 11 37 42 AM](https://github.com/NYCPlanning/labs-streets/assets/43344288/cec79f3e-4024-4482-97b2-40c3f201e4d5)
