### PR TITLE
Account for null do_path property in popup

### DIFF
--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -112,7 +112,7 @@ export default class MapPopupContent extends Component {
           boro,
           boroname: boroLookup[boro],
           last_date: moment(last_date).format('MMM D, YYYY'),
-          section_info: do_path.split('.com/')[1],
+          section_info: do_path === null ? null : do_path.split('.com/')[1],
         };
       });
 


### PR DESCRIPTION
This PR adds a check for section maps where `do_path` is null. When it is, just set `section_info` to null.
