### PR TITLE
remove link icon from local law name

### DIFF
--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -26,7 +26,7 @@
     <ul class="popup-list no-bullet no-margin">
       {{#each this.streetNameChanges as |nameChange|}}
         <li class="popup-button clearfix">
-          <strong class="link-name float-left"><FaIcon @icon="external-link-alt" />{{nameChange.properties.honor_name}}</strong>
+          <strong class="float-left">{{nameChange.properties.honor_name}}</strong>
           <span class="date float-right">{{nameChange.properties.lleffectdt}}</span>
         </li>
       {{/each}}


### PR DESCRIPTION
# Description
This PR takes out the link icon of local law names because the hyperlink was removed in a previous change.

## Ticket
Closes [AB#14258](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14258)

