### PR TITLE
Update default selected aerial layer

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -35,7 +35,7 @@ const getBoundsGeoJSON = (map) => {
 
 export const LayerVisibilityParams = new QueryParams({
   'selected-aerial': {
-    defaultValue: 'aerials-2016',
+    defaultValue: 'aerials-2022',
     refresh: true,
   },
   lat: {


### PR DESCRIPTION
Closes #366.

- Updates default selected aerial layer to be aerials-2022

![Screen Shot 2024-04-11 at 10 47 46 AM](https://github.com/NYCPlanning/labs-streets/assets/43344288/dcd0e51b-a80a-4ea3-9f52-481b056974fb)
