### PR TITLE
372 Update default ortho layer to 2024

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -35,7 +35,7 @@ const getBoundsGeoJSON = (map) => {
 
 export const LayerVisibilityParams = new QueryParams({
   'selected-aerial': {
-    defaultValue: 'aerials-2022',
+    defaultValue: 'aerials-2024',
     refresh: true,
   },
   lat: {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

# Acceptance criteria

- [ ] Update the default ortho layer shown to from 2022 to 2024. Example from last time we updated this can be found [here](https://github.com/NYCPlanning/labs-streets/pull/367/files).
Closes #372

Note: although I have made the requested changes, they were unnecessary; the site appears to disregard this value and show 2024 by default.
